### PR TITLE
Ignoring Build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 Library/
 obj/
 Temp/
+Build/
 
 # Files
 *.csproj


### PR DESCRIPTION
Adding the `Build/` directory to `.gitignore`, as most people are supposed to build their projects there.